### PR TITLE
Few Fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,13 +22,9 @@ bl_info = {
     "category": "Generic",
 }
 
-import os
-os.putenv("PYPPETEER_CHROMIUM_REVISION", "1230501")
-import pyppeteer.chromium_downloader as pyppeteer_downloader
-from importlib import reload
-reload(pyppeteer_downloader)
-
 from . import auto_load
+from .utils import reload_pyppeteer
+reload_pyppeteer()
 
 auto_load.init()
 

--- a/ops/install.py
+++ b/ops/install.py
@@ -9,7 +9,7 @@ from ..BetterPlayblast.install import missing_packages
 PYTHON = sys.executable
 SITE_PACKAGES = Path(PYTHON).parent.parent / "lib" / "site-packages"
 
-class InstallMissingPackages(bpy.types.Operator):
+class BP_PackageInstaller(bpy.types.Operator):
 	bl_idname = "bp.install_missing_packages"
 	bl_label = "Install Missing Packages"
 	bl_description = "Install the required packages for Better Playblast.\n*This may cause blender to freeze.*\n(Open the console first to see the installation progress)"

--- a/ops/playblast.py
+++ b/ops/playblast.py
@@ -65,6 +65,7 @@ class BP_Playblast(bpy.types.Operator):
 
 		# Write video file
 		bpy.ops.render.opengl(animation=True)
+		remove_function_from_handler(data_frame_capture, handler)
 		# Write JSON file
 		with open(json_filepath, 'w') as f:
 			json.dump(data, f, indent=4)

--- a/ops/playblast.py
+++ b/ops/playblast.py
@@ -3,6 +3,7 @@ import os
 import json
 from pathlib import Path
 from functools import partial
+from ..utils import reload_pyppeteer
 from ..utils.render_settings import *
 from ..utils.capture_data import *
 from ..utils.time import get_now
@@ -73,6 +74,7 @@ class BP_Playblast(bpy.types.Operator):
 		# Restoring render settings
 		restore_render_settings(context, render_settings=render_settings)
 
+		reload_pyppeteer()
 		pb = Playblast(video_filepath, json_filepath, metadatas=[MList.DATE, MList.FILE])
 		rendered_video = pb.render(preview=self.preview_process)
 

--- a/ops/playblast.py
+++ b/ops/playblast.py
@@ -79,6 +79,6 @@ class BP_Playblast(bpy.types.Operator):
 		og_filepath.parent.mkdir(parents=True, exist_ok=True)
 		if og_filepath.exists():
 			og_filepath.unlink()
-		video_filepath.replace(og_filepath)
+		rendered_video.replace(og_filepath)
 
 		return {'FINISHED'}

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -3,7 +3,7 @@ import bpy
 from . import pop_panel_decorator
 from ..addon import packages_installed
 from ..icons import get_icon
-from ..ops.install import InstallMissingPackages
+from ..ops.install import BP_PackageInstaller
 from ..ops.playblast import BP_Playblast
 
 class BP_MainPanel(bpy.types.Panel):
@@ -31,7 +31,7 @@ class BP_MainPanel(bpy.types.Panel):
         col = row.column()
         col.operator("wm.url_open", text="?").url = "https://example.com/docs" # TODO : replace with actual documentation
         row = box.row()
-        row.operator(InstallMissingPackages.bl_idname, text=InstallMissingPackages.bl_label, icon='PACKAGE')
+        row.operator(BP_PackageInstaller.bl_idname, text=BP_PackageInstaller.bl_label, icon='PACKAGE')
 
 @pop_panel_decorator(BP_MainPanel.bl_idname, icon="logo")
 def pop_panel(): pass

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,7 @@
+import os
+from importlib import reload
+
+def reload_pyppeteer():	
+	os.putenv("PYPPETEER_CHROMIUM_REVISION", "1230501")
+	import pyppeteer.chromium_downloader as pyppeteer_downloader
+	reload(pyppeteer_downloader)


### PR DESCRIPTION
- Refactors `pyppeteer` Chromium revision handling by moving reload logic to a utility function (`reload_pyppeteer` in `utils/__init__.py`), ensuring correct revision usage after rendering.
- Renames the package installation operator from `InstallMissingPackages` to `BP_PackageInstaller` for clarity and consistency in both definition and UI references.
- Minor code organization improvements.